### PR TITLE
Feature: array and depth calculation optimizations

### DIFF
--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -501,3 +501,4 @@ MonoBehaviour:
   targetRenderer: {fileID: 791980304}
   mTargetMaterial: {fileID: 0}
   maxPixelBaseline: 10
+  colorWeightToDepth01: {x: 0.1, y: 0.4, z: 0.8}

--- a/Assets/Scripts/ArrayUtil.cs
+++ b/Assets/Scripts/ArrayUtil.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public static class ArrayUtil
+{
+	public static T[,] ArrayOfValue<T>(T defaultValue, int rows, int cols) {
+		T[,] grid = new T[rows, cols];
+
+		for (int i = 0; i < rows; ++i) {
+			for (int j = 0; j < cols; ++j) {
+				grid[i, j] = defaultValue;
+			}
+		}
+
+		return grid;
+	}
+}

--- a/Assets/Scripts/ArrayUtil.cs.meta
+++ b/Assets/Scripts/ArrayUtil.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 38625bf8564a14741b395a52043516a9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/CopyWithHorizontalPixelTranslation.cs
+++ b/Assets/Scripts/CopyWithHorizontalPixelTranslation.cs
@@ -39,6 +39,8 @@ public class CopyWithHorizontalPixelTranslation : MonoBehaviour
 		}
 	}
 
+	const float minNegativeValue = -2.0f;
+
 	/// <summary>
 	/// Copies data from sourceAlbedo to targetAlbedo while applying a horizontal pixel translation according to depth information. This is a very basic view synthesis operation
 	/// </summary>
@@ -49,20 +51,20 @@ public class CopyWithHorizontalPixelTranslation : MonoBehaviour
 		int maxAlbedoX = source.width / 2;
 		int maxAlbedoY = source.height;
 
-		// create a depth map with default values initialized by C# to 0. assume that 0 = furthest possible depth / red in image. Overwrite with any proximal pixels
-		float[,] depthSurface = new float[maxAlbedoX, maxAlbedoY];
-
-		for (int i = 0; i < maxAlbedoX; ++i) {
-			for (int j = 0; j < maxAlbedoY; ++j) {
-				depthSurface[i, j] = float.NegativeInfinity;
-			}
-		}
+		// create a depth map with default value of -2.0f. We will do depth tests and keep pixels with depth values greater than -2.0f
+		float[,] depthSurface = ArrayUtil.ArrayOfValue(minNegativeValue, maxAlbedoX, maxAlbedoY);
 
 		if (destination == null) {
 			destination = new Texture2D(maxAlbedoX, source.height, source.format, false, false) {
 				filterMode = FilterMode.Point,
 				name = "synthesized albedo tex"
 			};
+		}
+
+		for (int i = 0; i < maxAlbedoX; ++i) {
+			for (int j = 0; j < maxAlbedoY; ++j) {
+				destination.SetPixel(i, j, Color.gray);
+			}
 		}
 
 		// the format that the demo image uses is non-overlapping R/G/B. R = background (-k2 to -k), green = (-k to +k), b = foreground (k to +k2)
@@ -76,13 +78,6 @@ public class CopyWithHorizontalPixelTranslation : MonoBehaviour
 			return (normalizedDepth - 0.5f) * 2;
 		};
 		
-		// for demo purposes, we will clear the image
-		for (int i = 0; i < maxAlbedoX; ++i) {
-			for (int j = 0; j < maxAlbedoY; ++j) {
-				destination.SetPixel(i, j, Color.grey);
-			}
-		}
-
 		for (int i = 0; i < maxAlbedoX; ++i) {
 			for (int j = 0; j < maxAlbedoY; ++j) {
 				// retrieve color in color section of original image

--- a/Assets/Scripts/CopyWithHorizontalPixelTranslation.cs
+++ b/Assets/Scripts/CopyWithHorizontalPixelTranslation.cs
@@ -58,12 +58,12 @@ public class CopyWithHorizontalPixelTranslation : MonoBehaviour
 			}
 		}
 
-				if (destination == null)
-		destination = new Texture2D(maxAlbedoX, source.height, source.format, false, false) 
-		{
-			filterMode = FilterMode.Point,
-			name = "right albedo tex"
-		};
+		if (destination == null) {
+			destination = new Texture2D(maxAlbedoX, source.height, source.format, false, false) {
+				filterMode = FilterMode.Point,
+				name = "synthesized albedo tex"
+			};
+		}
 
 		// the format that the demo image uses is non-overlapping R/G/B. R = background (-k2 to -k), green = (-k to +k), b = foreground (k to +k2)
 		// in our case the sign is really important. other things less important. so just do this linear sum


### PR DESCRIPTION
Transition to depth = dot(weight_vector, (r,g,b)). This is useful because the user-provided depth maps might need to have their depth function reconfigured in the future.

Added a utility for creating a 2D array of default values.